### PR TITLE
AM243x NETX BSD and PTP addons plus fixes

### DIFF
--- a/.project/templates/makefile_executable.xdt
+++ b/.project/templates/makefile_executable.xdt
@@ -125,6 +125,11 @@ FILES_`prop` := \
 	ti_enet_lwipif.c \
 			 % }
 		% }
+        % for(val of args.project.libs["common"]){
+            % if (val.startsWith("netx")) {
+    ti_enet_netxduo.c \
+             % }
+        % }
 
 	% }
 % }
@@ -418,6 +423,11 @@ SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
 		 % }
 	% }
+% for(val of args.project.libs["common"]){
+    % if (val.startsWith("netx")) {
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
+         % }
+    % }
 % }
 % if (args.project.device == "am243x" && ((args.project.cgt == "gcc-aarch64") || (args.project.cgt == "gcc-armv7")) && (args.project.lnkpreprocessor_gcc != undefined)) {
 $(LNK_FILES_common): $(LNK_FILES_PREPROCESSOR_common)

--- a/examples/networking/netxduo/enet_netxduo_cpsw_mac/am243x-evm/r5fss0-0_threadx/gcc-armv7/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_mac/am243x-evm/r5fss0-0_threadx/gcc-armv7/makefile
@@ -50,6 +50,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -218,6 +219,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_mac/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_mac/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -53,6 +53,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -236,6 +237,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_mac/am243x-lp/r5fss0-0_threadx/gcc-armv7/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_mac/am243x-lp/r5fss0-0_threadx/gcc-armv7/makefile
@@ -50,6 +50,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -218,6 +219,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_mac/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_mac/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -53,6 +53,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -236,6 +237,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_switch/am243x-evm/r5fss0-0_threadx/gcc-armv7/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_switch/am243x-evm/r5fss0-0_threadx/gcc-armv7/makefile
@@ -50,6 +50,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -218,6 +219,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_switch/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_switch/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -53,6 +53,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -236,6 +237,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_switch/am243x-lp/r5fss0-0_threadx/gcc-armv7/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_switch/am243x-lp/r5fss0-0_threadx/gcc-armv7/makefile
@@ -50,6 +50,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -218,6 +219,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_switch/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_switch/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -53,6 +53,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -236,6 +237,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_tcp_client/am243x-evm/r5fss0-0_threadx/gcc-armv7/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_tcp_client/am243x-evm/r5fss0-0_threadx/gcc-armv7/makefile
@@ -50,6 +50,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -218,6 +219,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_tcp_client/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_tcp_client/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -53,6 +53,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -236,6 +237,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_tcp_client/am243x-lp/r5fss0-0_threadx/gcc-armv7/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_tcp_client/am243x-lp/r5fss0-0_threadx/gcc-armv7/makefile
@@ -50,6 +50,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -218,6 +219,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_tcp_client/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_tcp_client/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -53,6 +53,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -236,6 +237,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_tcp_server/am243x-evm/r5fss0-0_threadx/gcc-armv7/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_tcp_server/am243x-evm/r5fss0-0_threadx/gcc-armv7/makefile
@@ -50,6 +50,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -218,6 +219,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_tcp_server/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_tcp_server/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -53,6 +53,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -236,6 +237,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_tcp_server/am243x-lp/r5fss0-0_threadx/gcc-armv7/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_tcp_server/am243x-lp/r5fss0-0_threadx/gcc-armv7/makefile
@@ -50,6 +50,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -218,6 +219,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_tcp_server/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_tcp_server/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -53,6 +53,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -236,6 +237,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_udp_client/am243x-evm/r5fss0-0_threadx/gcc-armv7/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_udp_client/am243x-evm/r5fss0-0_threadx/gcc-armv7/makefile
@@ -50,6 +50,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -218,6 +219,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_udp_client/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_udp_client/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -53,6 +53,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -236,6 +237,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_udp_client/am243x-lp/r5fss0-0_threadx/gcc-armv7/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_udp_client/am243x-lp/r5fss0-0_threadx/gcc-armv7/makefile
@@ -50,6 +50,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -218,6 +219,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_cpsw_udp_client/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/networking/netxduo/enet_netxduo_cpsw_udp_client/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -53,6 +53,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -236,6 +237,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_icssg_mac/am243x-evm/r5fss0-0_threadx/gcc-armv7/makefile
+++ b/examples/networking/netxduo/enet_netxduo_icssg_mac/am243x-evm/r5fss0-0_threadx/gcc-armv7/makefile
@@ -50,6 +50,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -220,6 +221,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_icssg_mac/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/networking/netxduo/enet_netxduo_icssg_mac/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -53,6 +53,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -238,6 +239,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_icssg_mac/am243x-lp/r5fss0-0_threadx/gcc-armv7/makefile
+++ b/examples/networking/netxduo/enet_netxduo_icssg_mac/am243x-lp/r5fss0-0_threadx/gcc-armv7/makefile
@@ -50,6 +50,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -220,6 +221,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_icssg_mac/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/networking/netxduo/enet_netxduo_icssg_mac/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -53,6 +53,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -238,6 +239,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_icssg_switch/am243x-evm/r5fss0-0_threadx/gcc-armv7/makefile
+++ b/examples/networking/netxduo/enet_netxduo_icssg_switch/am243x-evm/r5fss0-0_threadx/gcc-armv7/makefile
@@ -50,6 +50,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -220,6 +221,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_icssg_switch/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/networking/netxduo/enet_netxduo_icssg_switch/am243x-evm/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -53,6 +53,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -238,6 +239,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_icssg_switch/am243x-lp/r5fss0-0_threadx/gcc-armv7/makefile
+++ b/examples/networking/netxduo/enet_netxduo_icssg_switch/am243x-lp/r5fss0-0_threadx/gcc-armv7/makefile
@@ -50,6 +50,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -220,6 +221,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/examples/networking/netxduo/enet_netxduo_icssg_switch/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
+++ b/examples/networking/netxduo/enet_netxduo_icssg_switch/am243x-lp/r5fss0-0_threadx/ti-arm-clang/makefile
@@ -53,6 +53,7 @@ FILES_common := \
 	ti_enet_open_close.c \
 	ti_enet_soc.c \
 	ti_enet_lwipif.c \
+    ti_enet_netxduo.c \
 
 FILES_PATH_common = \
 	.. \
@@ -238,6 +239,7 @@ SYSCFG_GEN_FILES+=generated/ti_enet_config.c generated/ti_enet_config.h
 SYSCFG_GEN_FILES+=generated/ti_enet_open_close.c generated/ti_enet_open_close.h
 SYSCFG_GEN_FILES+=generated/ti_enet_soc.c
 SYSCFG_GEN_FILES+=generated/ti_enet_lwipif.c generated/ti_enet_lwipif.h
+SYSCFG_GEN_FILES+=generated/ti_enet_netxduo.c generated/ti_enet_netxduo.h
 
 SYSTEM_FLAG ?= false
 

--- a/source/kernel/threadx/.project/project_am243x.js
+++ b/source/kernel/threadx/.project/project_am243x.js
@@ -234,6 +234,7 @@ const asmfiles = {
         "CpuId_armv7r_asm.S",
         "PmuP_armv7r_asm.S",
         // DPL R5
+        "Mutex_armv7r_asm.S",
         "HwiP_armv7r_handlers_threadx_asm.S",
         "HwiP_armv7r_vectors_threadx_asm.S",
         // R5 port

--- a/source/kernel/threadx/dpl/r5/Mutex_armv7r_asm.S
+++ b/source/kernel/threadx/dpl/r5/Mutex_armv7r_asm.S
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (C) 2018-2021 Texas Instruments Incorporated
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+.text
+
+.equ locked, 0x1
+.equ unlocked, 0x0
+
+//==============================================================================
+//void lock_mutex(void * mutex);
+//uint32_t try_lock_mutex(void * mutex);
+//void unlock_mutex(void * mutex);
+//==============================================================================
+    .global lock_mutex
+    .global try_lock_mutex
+    .global unlock_mutex
+    .global lock_mutex_wait
+    .global lock_mutex_locked
+
+.macro wait_for_update
+    wfi                     // Indicate opportunity to enter low-power state
+.endm
+
+.macro signal_update
+                            // No software signalling operation
+.endm
+
+// lock_mutex
+lock_mutex:
+    mov     r1, #1
+lock_mutex_retry:
+    ldrex   r2, [r0]
+    cmp     r2, r1          // Test if mutex is locked or unlocked
+    beq     lock_mutex_wait           // If locked - wait for it to be released, from 2
+    strexne r2, r1, [r0]    // Not locked, attempt to lock it
+    cmpne   r2, #1          // Check if Store-Exclusive failed
+    beq     lock_mutex_retry           // Failed - retry from 1
+    // Lock acquired
+    dmb                     // Required before accessing protected resource
+    bx      lr
+
+lock_mutex_wait:            // Take appropriate action while waiting for mutex to become unlocked
+    wait_for_update
+    b       lock_mutex_retry           // Retry from 1(lock_mutex_retry)
+
+// try_lock_mutex
+try_lock_mutex:
+    mov     r1, #1
+    ldrex   r2, [r0]
+    cmp     r2, r1          // Test if mutex is locked or unlocked
+    beq     lock_mutex_locked           // If locked, return 1
+    strexne r2, r1, [r0]    // Not locked, attempt to lock it
+    // Lock acquired
+    dmb                     // Required before accessing protected resource
+    mov     r0, #0
+    bx      lr
+lock_mutex_locked:            // Take appropriate action while waiting for mutex to become unlocked
+    mov     r0, #1
+    bx      lr           // return with mutex locked
+
+// unlock_mutex
+unlock_mutex:
+    mov     r1, #0
+    dmb                     // Required before releasing protected resource
+    str     r1, [r0]        // Unlock mutex
+    signal_update
+    bx      lr
+
+        .end
+

--- a/source/kernel/threadx/makefile.am243x.r5f.gcc-armv7
+++ b/source/kernel/threadx/makefile.am243x.r5f.gcc-armv7
@@ -236,6 +236,7 @@ ASMFILES_common := \
     CacheP_armv7r_asm.S \
     CpuId_armv7r_asm.S \
     PmuP_armv7r_asm.S \
+    Mutex_armv7r_asm.S \
     HwiP_armv7r_handlers_threadx_asm.S \
     HwiP_armv7r_vectors_threadx_asm.S \
     tx_thread_context_restore.S \

--- a/source/kernel/threadx/makefile.am243x.r5f.ti-arm-clang
+++ b/source/kernel/threadx/makefile.am243x.r5f.ti-arm-clang
@@ -236,6 +236,7 @@ ASMFILES_common := \
     CacheP_armv7r_asm.S \
     CpuId_armv7r_asm.S \
     PmuP_armv7r_asm.S \
+    Mutex_armv7r_asm.S \
     HwiP_armv7r_handlers_threadx_asm.S \
     HwiP_armv7r_vectors_threadx_asm.S \
     tx_thread_context_restore.S \

--- a/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc/tx_port.h
+++ b/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc/tx_port.h
@@ -108,6 +108,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 
 /* Define ThreadX basic types for this port.  */ 
@@ -121,6 +122,7 @@ typedef long                                    LONG;
 typedef unsigned long                           ULONG;
 typedef short                                   SHORT;
 typedef unsigned short                          USHORT;
+typedef uint64_t                                ULONG64;
 
 
 /* Define the priority levels for ThreadX.  Legal values range
@@ -221,7 +223,7 @@ typedef unsigned short                          USHORT;
    for the multiple macros is so that backward compatibility can be maintained with 
    existing ThreadX kernel awareness modules.  */
 
-#define TX_THREAD_EXTENSION_0          
+#define TX_THREAD_EXTENSION_0          int bsd_errno;
 #define TX_THREAD_EXTENSION_1                  
 #define TX_THREAD_EXTENSION_2          
 #define TX_THREAD_EXTENSION_3          

--- a/source/networking/netxduo/.project/project_am243x.js
+++ b/source/networking/netxduo/.project/project_am243x.js
@@ -521,17 +521,17 @@ const files = {
         "nx_auto_ip.c",
 
         // azure-iot
-        // "nx_azure_iot.c",
-        // "nx_azure_iot_adu_agent.c",
-        // "nx_azure_iotu_adu_root_key.c",
-        // "nx_azure_iotu_hub_client.c",
-        // "nx_azure_iotu_hub_client_properties.c",
-        // "nx_azure_iotu_json_reader.c", 
-        // "nx_azure_iotu_json_writer.c",
-        // "nx_azure_iotu_provisionning_client.c",
+        "nx_azure_iot.c",
+        "nx_azure_iot_adu_agent.c",
+        "nx_azure_iot_adu_root_key.c",
+        "nx_azure_iot_hub_client.c",
+        "nx_azure_iot_hub_client_properties.c",
+        "nx_azure_iot_json_reader.c", 
+        "nx_azure_iot_json_writer.c",
+        "nx_azure_iot_provisioning_client.c",
 
         // BSD
-        // "nxd_bsd.c",
+        "nxd_bsd.c",
 
         // Cloud
         "nx_cloud.c",
@@ -573,7 +573,7 @@ const files = {
         "nx_pppoe_server.c",
 
         // PTP
-        // "nxd_ptp_client.c",
+        "nxd_ptp_client.c",
 
         // RTP
         "nx_rtp_sender.c",
@@ -616,8 +616,8 @@ const filedirs = {
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/src",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip",
-        // "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot",
-        // "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns",
@@ -629,7 +629,7 @@ const filedirs = {
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe",
-        // "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp",
@@ -647,6 +647,9 @@ const includes = {
         "${MCU_PLUS_SDK_PATH}/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc",
         "${MCU_PLUS_SDK_PATH}/source/kernel/threadx/threadx_src/common/inc",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/inc",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/inc",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/ports",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/crypto_libraries/inc",
         "${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/common/inc",
         "${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/ports/generic/inc",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet",
@@ -658,8 +661,8 @@ const includes = {
         "${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include",
         "${MCU_PLUS_SDK_PATH}/source/networking/enet/soc/k3/am64x_am243x",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip",
-        // "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot",
-        // "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns",
@@ -671,7 +674,7 @@ const includes = {
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe",
-        // "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp",
@@ -681,6 +684,7 @@ const includes = {
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/tftp",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/web",
         "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/websocket",
+        "${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot/azure-sdk-for-c/sdk/inc",
     ],
 };
 

--- a/source/networking/netxduo/.project/project_am243x.js
+++ b/source/networking/netxduo/.project/project_am243x.js
@@ -521,14 +521,14 @@ const files = {
         "nx_auto_ip.c",
 
         // azure-iot
-        "nx_azure_iot.c",
-        "nx_azure_iot_adu_agent.c",
-        "nx_azure_iot_adu_root_key.c",
-        "nx_azure_iot_hub_client.c",
-        "nx_azure_iot_hub_client_properties.c",
-        "nx_azure_iot_json_reader.c", 
-        "nx_azure_iot_json_writer.c",
-        "nx_azure_iot_provisioning_client.c",
+        // "nx_azure_iot.c",
+        // "nx_azure_iot_adu_agent.c",
+        // "nx_azure_iot_adu_root_key.c",
+        // "nx_azure_iot_hub_client.c",
+        // "nx_azure_iot_hub_client_properties.c",
+        // "nx_azure_iot_json_reader.c", 
+        // "nx_azure_iot_json_writer.c",
+        // "nx_azure_iot_provisioning_client.c",
 
         // BSD
         "nxd_bsd.c",

--- a/source/networking/netxduo/makefile.am243x.r5f.gcc-armv7
+++ b/source/networking/netxduo/makefile.am243x.r5f.gcc-armv7
@@ -529,6 +529,7 @@ FILES_common := \
     nx_udp_source_extract.c \
     nx_utility.c \
     nx_auto_ip.c \
+    nxd_bsd.c \
     nx_cloud.c \
     nxd_dhcp_client.c \
     nxd_dhcp_server.c \
@@ -546,6 +547,7 @@ FILES_common := \
     nx_ppp.c \
     nx_pppoe_client.c \
     nx_pppoe_server.c \
+    nxd_ptp_client.c \
     nx_rtp_sender.c \
     nx_rtsp_server.c \
     nxd_smtp_client.c \
@@ -567,6 +569,8 @@ FILES_PATH_common = \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/src \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip \
+    ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot \
+    ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns \
@@ -578,6 +582,7 @@ FILES_PATH_common = \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3 \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe \
+    ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp \
@@ -594,6 +599,9 @@ INCLUDES_common := \
     -I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc \
     -I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/threadx_src/common/inc \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/inc \
+    -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/inc \
+    -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/ports \
+    -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/crypto_libraries/inc \
     -I${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/common/inc \
     -I${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/ports/generic/inc \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet \
@@ -605,6 +613,8 @@ INCLUDES_common := \
     -I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include \
     -I${MCU_PLUS_SDK_PATH}/source/networking/enet/soc/k3/am64x_am243x \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip \
+    -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot \
+    -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns \
@@ -616,6 +626,7 @@ INCLUDES_common := \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3 \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe \
+    -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp \
@@ -625,6 +636,7 @@ INCLUDES_common := \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/tftp \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/web \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/websocket \
+    -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot/azure-sdk-for-c/sdk/inc \
 
 DEFINES_common := \
     -DSOC_AM243X \

--- a/source/networking/netxduo/makefile.am243x.r5f.ti-arm-clang
+++ b/source/networking/netxduo/makefile.am243x.r5f.ti-arm-clang
@@ -529,6 +529,7 @@ FILES_common := \
     nx_udp_source_extract.c \
     nx_utility.c \
     nx_auto_ip.c \
+    nxd_bsd.c \
     nx_cloud.c \
     nxd_dhcp_client.c \
     nxd_dhcp_server.c \
@@ -546,6 +547,7 @@ FILES_common := \
     nx_ppp.c \
     nx_pppoe_client.c \
     nx_pppoe_server.c \
+    nxd_ptp_client.c \
     nx_rtp_sender.c \
     nx_rtsp_server.c \
     nxd_smtp_client.c \
@@ -567,6 +569,8 @@ FILES_PATH_common = \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/src \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip \
+    ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot \
+    ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns \
@@ -578,6 +582,7 @@ FILES_PATH_common = \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3 \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe \
+    ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp \
     ${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp \
@@ -594,6 +599,9 @@ INCLUDES_common := \
     -I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/ports/ti_arm_gcc_clang_cortex_r5/inc \
     -I${MCU_PLUS_SDK_PATH}/source/kernel/threadx/threadx_src/common/inc \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/common/inc \
+    -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/inc \
+    -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/nx_secure/ports \
+    -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/crypto_libraries/inc \
     -I${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/common/inc \
     -I${MCU_PLUS_SDK_PATH}/source/fs/filex/filex_src/ports/generic/inc \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_enet \
@@ -605,6 +613,8 @@ INCLUDES_common := \
     -I${MCU_PLUS_SDK_PATH}/source/networking/enet/hw_include \
     -I${MCU_PLUS_SDK_PATH}/source/networking/enet/soc/k3/am64x_am243x \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/auto_ip \
+    -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot \
+    -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/BSD \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/cloud \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dhcp \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/dns \
@@ -616,6 +626,7 @@ INCLUDES_common := \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pop3 \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ppp \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/pppoe \
+    -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/ptp \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtp \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/rtsp \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/smtp \
@@ -625,6 +636,7 @@ INCLUDES_common := \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/tftp \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/web \
     -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/websocket \
+    -I${MCU_PLUS_SDK_PATH}/source/networking/netxduo/netxduo_src/addons/azure_iot/azure-sdk-for-c/sdk/inc \
 
 DEFINES_common := \
     -DSOC_AM243X \

--- a/source/networking/netxduo/netxduo_enet/nx_user.h
+++ b/source/networking/netxduo/netxduo_enet/nx_user.h
@@ -731,9 +731,12 @@
    to NetX Duo API for notifying the application of socket events, such as TCP connection and disconnect
    completion.  These extended notify functions are mainly used by the BSD wrapper. The default is this
    feature is disabled.  */
-/*
+
 #define NX_ENABLE_EXTENDED_NOTIFY_SUPPORT
-*/
+
+#define NX_SECURE_ENABLE
+
+#define NXD_MQTT_CLOUD_ENABLE
 
 /* Defined, ASSERT is disabled. The default is enabled. */
 /*


### PR DESCRIPTION
Add the PTP and BSD addons to the NETX build. 
Also includes the implementation of the ARM Mutexes for the R5 in the ThreadX DPL which are used for some driver tests. 
Fixed an issue with the build of some NEXT demo and tests.