### PR TITLE
am243x : mcu_plus_sdk : Modify makefile template of CPSW and ICSSG

### DIFF
--- a/source/networking/enet/.project/project_am243x_cpsw.js
+++ b/source/networking/enet/.project/project_am243x_cpsw.js
@@ -13,7 +13,6 @@ const files = {
         "enet_rm.c",
         "enet_rm_ioctl.c",
         "enet_rm_ioctl_register.c",
-        "enet_osal_dflt.c",
         "enet_utils_dflt.c",
         "enet_phymdio_dflt.c",
         "enet_phymdio_dflt_ioctl.c",
@@ -158,6 +157,7 @@ const defines_r5f = {
         "ENET_CFG_TRACE_LEVEL=3",
         "ENET_ENABLE_PER_CPSW=1",
         "ENABLE_ENET_LOG",
+        "ENET_CPSW",
     ],
     debug: [
         "ENET_CFG_DEV_ERROR=1",

--- a/source/networking/enet/.project/project_am243x_icssg.js
+++ b/source/networking/enet/.project/project_am243x_icssg.js
@@ -13,7 +13,6 @@ const files = {
         "enet_rm.c",
         "enet_rm_ioctl.c",
         "enet_rm_ioctl_register.c",
-        "enet_osal_dflt.c",
         "enet_utils_dflt.c",
         "enet_phymdio_dflt.c",
         "mod_null.c",
@@ -136,6 +135,7 @@ const defines_r5f = {
         "ENET_CFG_TRACE_LEVEL=3",
         "ENET_ENABLE_PER_ICSSG=1",
         "ENABLE_ENET_LOG",
+        "ENET_ICSSG",
     ],
 
     debug: [

--- a/source/networking/enet/.project/project_cpsw_lwipif_freertos.js
+++ b/source/networking/enet/.project/project_cpsw_lwipif_freertos.js
@@ -124,6 +124,7 @@ const defines_r5f = {
         "ENET_CFG_TRACE_LEVEL=3",
         "ENET_ENABLE_PER_CPSW=1",
         "ENABLE_ENET_LOG",
+        "ENET_CPSW",
     ],
     debug: [
         "ENET_CFG_DEV_ERROR=1",

--- a/source/networking/enet/.project/project_cpsw_lwipif_nortos.js
+++ b/source/networking/enet/.project/project_cpsw_lwipif_nortos.js
@@ -114,6 +114,7 @@ const defines_r5f = {
         "ENET_CFG_TRACE_LEVEL=3",
         "ENET_ENABLE_PER_CPSW=1",
         "ENABLE_ENET_LOG",
+        "ENET_CPSW",
     ],
     debug: [
         "ENET_CFG_DEV_ERROR=1",

--- a/source/networking/enet/.project/project_icssg_lwipif_freertos.js
+++ b/source/networking/enet/.project/project_icssg_lwipif_freertos.js
@@ -67,6 +67,7 @@ const defines_r5f = {
         "ENET_CFG_TRACE_LEVEL=3",
         "ENET_ENABLE_PER_ICSSG=1",
         "ENABLE_ENET_LOG",
+        "ENET_ICSSG",
     ],
     debug: [
         "ENET_CFG_DEV_ERROR=1",

--- a/source/networking/enet/.project/project_icssg_lwipif_ic_freertos.js
+++ b/source/networking/enet/.project/project_icssg_lwipif_ic_freertos.js
@@ -107,6 +107,7 @@ const defines_r5f = {
         "ENET_CFG_PRINT_ENABLE",
         "ENET_CFG_TRACE_LEVEL=3",
         "ENABLE_ENET_LOG",
+        "ENET_ICSSG",
     ],
     debug: [
         "ENET_CFG_DEV_ERROR=1",

--- a/source/networking/enet/.project/project_icssg_lwipif_nortos.js
+++ b/source/networking/enet/.project/project_icssg_lwipif_nortos.js
@@ -67,6 +67,7 @@ const defines_r5f = {
         "ENET_CFG_TRACE_LEVEL=3",
         "ENET_ENABLE_PER_ICSSG=1",
         "ENABLE_ENET_LOG",
+        "ENET_ICSSG",
     ],
     debug: [
         "ENET_CFG_DEV_ERROR=1",


### PR DESCRIPTION
-Enet LLD has been cleaned up to meet the functional safety standards. To incorporate those changes in mcu_plus_sdk, makefile templates for building the necessary libraries are modified

The following changes aims to build the enet lld libs correctly without any errors

-added defines for IOCTL macro inclusion coressponding to the library being build
-removed the .c files which has been deleted in enet lld