### PR TITLE
[dpl] Allow disabling shared memory log writer prelude

### DIFF
--- a/source/drivers/soc/am263px/soc_rcm.c
+++ b/source/drivers/soc/am263px/soc_rcm.c
@@ -195,7 +195,7 @@ const SOC_RcmClkSrcInfo gCLKOUTClkSrcInfoMap =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for MCAN
  */
-static uint16_t gMcanClkSrcValMap[] =
+static const uint16_t gMcanClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -218,7 +218,7 @@ static uint16_t gMcanClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for OSPI
  */
-static uint16_t gOspiClkSrcValMap[] =
+static const uint16_t gOspiClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -241,7 +241,7 @@ static uint16_t gOspiClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for RTI
  */
-static uint16_t gRtiClkSrcValMap[] =
+static const uint16_t gRtiClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -264,7 +264,7 @@ static uint16_t gRtiClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for WDT
  */
-static uint16_t gWdtClkSrcValMap[] =
+static const uint16_t gWdtClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -287,7 +287,7 @@ static uint16_t gWdtClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for McSPI
  */
-static uint16_t gMcSpiClkSrcValMap[] =
+static const uint16_t gMcSpiClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -310,7 +310,7 @@ static uint16_t gMcSpiClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for MMC
  */
-static uint16_t gMmcClkSrcValMap[] =
+static const uint16_t gMmcClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -333,7 +333,7 @@ static uint16_t gMmcClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for ICSSM UART
  */
-static uint16_t gIcssmUartClkSrcValMap[] =
+static const uint16_t gIcssmUartClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -356,7 +356,7 @@ static uint16_t gIcssmUartClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for CPTS
  */
-static uint16_t gCptsClkSrcValMap[] =
+static const uint16_t gCptsClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -402,7 +402,7 @@ static uint16_t gCptsClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for ControlSS PLL
  */
-static uint16_t gControlssPllClkSrcValMap[] =
+static const uint16_t gControlssPllClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = UNSUPPORTED_CLOCK_SOURCE,
@@ -425,7 +425,7 @@ static uint16_t gControlssPllClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for I2C
  */
-static uint16_t gI2cClkSrcValMap[] =
+static const uint16_t gI2cClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -448,7 +448,7 @@ static uint16_t gI2cClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for LIN
  */
-static uint16_t gLinUartClkSrcValMap[] =
+static const uint16_t gLinUartClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -471,7 +471,7 @@ static uint16_t gLinUartClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for R5F and SYSCLK
  */
-static uint16_t gR5SysClkSrcValMap[] =
+static const uint16_t gR5SysClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = UNSUPPORTED_CLOCK_SOURCE,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = UNSUPPORTED_CLOCK_SOURCE,
@@ -494,7 +494,7 @@ static uint16_t gR5SysClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for Trace
  */
-static uint16_t gTraceClkSrcValMap[] =
+static const uint16_t gTraceClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = UNSUPPORTED_CLOCK_SOURCE,
@@ -517,7 +517,7 @@ static uint16_t gTraceClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for CLKOUT
  */
-static uint16_t gClkoutClkSrcValMap[] =
+static const uint16_t gClkoutClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = UNSUPPORTED_CLOCK_SOURCE,
@@ -540,7 +540,7 @@ static uint16_t gClkoutClkSrcValMap[] =
  * @details
  *  Mapping Array between Reset Cause Bit and Reset Cause
  */
-static SOC_RcmResetCause gResetBitToResetCause[12U] =
+static cosnt SOC_RcmResetCause gResetBitToResetCause[12U] =
 {
     SOC_RcmResetCause_POWER_ON_RESET,
     SOC_RcmResetCause_WARM_RESET,
@@ -869,7 +869,7 @@ static uint32_t SBL_rcmIsDualCoreSwitchSupported(uint32_t cpuId)
  */
 static void SOC_rcmGetClkSrcAndDivReg (SOC_RcmPeripheralId periphId,
                                 SOC_RcmPeripheralClockSource clkSource,
-                                uint16_t *clkSrcVal,
+                                volatile uint16_t *clkSrcVal,
                                 volatile uint32_t **clkSrcReg,
                                 volatile uint32_t **clkdDivReg)
 {
@@ -2066,7 +2066,7 @@ int32_t SOC_rcmSetPeripheralClock (SOC_RcmPeripheralId periphId,
                                       uint32_t freqHz)
 {
     volatile uint32_t   *ptrClkSrcReg, *ptrClkDivReg;
-    uint16_t            clkSrcVal;
+    volatile uint16_t   clkSrcVal;
     uint32_t            clkDivisor;
     int32_t             retVal;
     uint32_t            Finp;

--- a/source/drivers/soc/am263x/soc_rcm.c
+++ b/source/drivers/soc/am263x/soc_rcm.c
@@ -195,7 +195,7 @@ const SOC_RcmClkSrcInfo gCLKOUTClkSrcInfoMap =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for MCAN
  */
-static uint16_t gMcanClkSrcValMap[] =
+static const uint16_t gMcanClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -218,7 +218,7 @@ static uint16_t gMcanClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for QSPI
  */
-static uint16_t gQspiClkSrcValMap[] =
+static const uint16_t gQspiClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -241,7 +241,7 @@ static uint16_t gQspiClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for RTI
  */
-static uint16_t gRtiClkSrcValMap[] =
+static const uint16_t gRtiClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -264,7 +264,7 @@ static uint16_t gRtiClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for WDT
  */
-static uint16_t gWdtClkSrcValMap[] =
+static const uint16_t gWdtClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -287,7 +287,7 @@ static uint16_t gWdtClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for McSPI
  */
-static uint16_t gMcSpiClkSrcValMap[] =
+static const uint16_t gMcSpiClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -310,7 +310,7 @@ static uint16_t gMcSpiClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for MMC
  */
-static uint16_t gMmcClkSrcValMap[] =
+static const uint16_t gMmcClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -333,7 +333,7 @@ static uint16_t gMmcClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for ICSSM UART
  */
-static uint16_t gIcssmUartClkSrcValMap[] =
+static const uint16_t gIcssmUartClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -356,7 +356,7 @@ static uint16_t gIcssmUartClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for CPTS
  */
-static uint16_t gCptsClkSrcValMap[] =
+static const uint16_t gCptsClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -379,7 +379,7 @@ static uint16_t gCptsClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for GPMC
  */
-static uint16_t gGpmcClkSrcValMap[] =
+static const uint16_t gGpmcClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -402,7 +402,7 @@ static uint16_t gGpmcClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for ControlSS PLL
  */
-static uint16_t gControlssPllClkSrcValMap[] =
+static const uint16_t gControlssPllClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = UNSUPPORTED_CLOCK_SOURCE,
@@ -425,7 +425,7 @@ static uint16_t gControlssPllClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for I2C
  */
-static uint16_t gI2cClkSrcValMap[] =
+static const uint16_t gI2cClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -448,7 +448,7 @@ static uint16_t gI2cClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for LIN
  */
-static uint16_t gLinUartClkSrcValMap[] =
+static const uint16_t gLinUartClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = 0x222U,
@@ -471,7 +471,7 @@ static uint16_t gLinUartClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for R5F and SYSCLK
  */
-static uint16_t gR5SysClkSrcValMap[] =
+static const uint16_t gR5SysClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = UNSUPPORTED_CLOCK_SOURCE,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = UNSUPPORTED_CLOCK_SOURCE,
@@ -494,7 +494,7 @@ static uint16_t gR5SysClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for Trace
  */
-static uint16_t gTraceClkSrcValMap[] =
+static const uint16_t gTraceClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = UNSUPPORTED_CLOCK_SOURCE,
@@ -517,7 +517,7 @@ static uint16_t gTraceClkSrcValMap[] =
  * @details
  *  Mapping Array between Clock mode and Clock Mode Value for CLKOUT
  */
-static uint16_t gClkoutClkSrcValMap[] =
+static const uint16_t gClkoutClkSrcValMap[] =
 {
     [SOC_RcmPeripheralClockSource_XTALCLK]                     = 0x666U,
     [SOC_RcmPeripheralClockSource_SYS_CLK]                     = UNSUPPORTED_CLOCK_SOURCE,
@@ -540,7 +540,7 @@ static uint16_t gClkoutClkSrcValMap[] =
  * @details
  *  Mapping Array between Reset Cause Bit and Reset Cause
  */
-static SOC_RcmResetCause gResetBitToResetCause[12U] =
+static const SOC_RcmResetCause gResetBitToResetCause[12U] =
 {
     SOC_RcmResetCause_POWER_ON_RESET,
     SOC_RcmResetCause_WARM_RESET,
@@ -869,7 +869,7 @@ static uint32_t SBL_rcmIsDualCoreSwitchSupported(uint32_t cpuId)
  */
 static void SOC_rcmGetClkSrcAndDivReg (SOC_RcmPeripheralId periphId,
                                 SOC_RcmPeripheralClockSource clkSource,
-                                uint16_t *clkSrcVal,
+                                volatile uint16_t *clkSrcVal,
                                 volatile uint32_t **clkSrcReg,
                                 volatile uint32_t **clkdDivReg)
 {
@@ -2030,7 +2030,7 @@ int32_t SOC_rcmSetPeripheralClock (SOC_RcmPeripheralId periphId,
                                       uint32_t freqHz)
 {
     volatile uint32_t   *ptrClkSrcReg, *ptrClkDivReg;
-    uint16_t            clkSrcVal;
+    uint16_t            volatile clkSrcVal;
     uint32_t            clkDivisor;
     int32_t             retVal;
     uint32_t            Finp;

--- a/source/kernel/dpl/DebugP.h
+++ b/source/kernel/dpl/DebugP.h
@@ -294,6 +294,19 @@ void DebugP_logZoneRestore(uint32_t logZoneMask);
  */
 void DebugP_shmLogWriterInit(DebugP_ShmLog *shmLog, uint16_t selfCoreId);
 
+
+/**
+ * \brief Enable auto prelude for shared memory log writer
+ */
+void DebugP_shmLogWriterPreludeEnable();
+
+/**
+ * \brief Disable auto prelude for shared memory log writer
+ * 
+ * This is useful for creating structured logs
+ */
+void DebugP_shmLogWriterPreludeDisable();
+
 /**
  * \brief Write a character to shared memory log
  *

--- a/source/kernel/nortos/dpl/common/DebugP_shmLogWriter.c
+++ b/source/kernel/nortos/dpl/common/DebugP_shmLogWriter.c
@@ -39,6 +39,7 @@
 
 static DebugP_ShmLog *gDebugShmLogWriter = NULL;
 static const char *gDebugShmLogWriterSelfCoreName = "unknown";
+static uint8_t gDebugShmLogWriterPreludeEnabled = 0;
 
 void DebugP_shmLogWriterPutLine(const uint8_t *buf, uint16_t num_bytes);
 
@@ -49,6 +50,7 @@ void DebugP_shmLogWriterInit(DebugP_ShmLog *shmLog, uint16_t selfCoreId)
     gDebugShmLogWriter->rdIndex = 0;
     gDebugShmLogWriter->wrIndex = 0;
     gDebugShmLogWriter->isValid = DebugP_SHM_LOG_IS_VALID;
+    gDebugShmLogWriterPreludeEnabled = 1;
 }
 
 void DebugP_shmLogWriterPutLine(const uint8_t *buf, uint16_t num_bytes)
@@ -118,7 +120,7 @@ void DebugP_shmLogWriterPutChar(char character)
 static uint8_t lineBuf[DebugP_SHM_LOG_WRITER_LINE_BUF_SIZE+UNSIGNED_INTEGERVAL_TWO]; /* +2 to add \r\n char at end of string in worst case */
 static uint32_t lineBufIndex = 0;
 
-    if(lineBufIndex==0U)
+    if(lineBufIndex==0U && gDebugShmLogWriterPreludeEnabled)
     {
         uint64_t curTime = ClockP_getTimeUsec();
 
@@ -154,3 +156,11 @@ static uint32_t lineBufIndex = 0;
     }
 }
 
+
+void DebugP_shmLogWriterPreludeEnable(){
+    gDebugShmLogWriterPreludeEnabled = 1;
+}
+
+void DebugP_shmLogWriterPreludeDisable(){
+    gDebugShmLogWriterPreludeEnabled = 0;
+}


### PR DESCRIPTION
Users cannot create structured logs when the log lines are always prefixed with the prelude