### PR TITLE
Fix Flash_quirkSpansionUNHYSADisable function

### DIFF
--- a/source/board/flash/ospi/flash_nor_ospi.c
+++ b/source/board/flash/ospi/flash_nor_ospi.c
@@ -1373,12 +1373,19 @@ static void Flash_norOspiClose(Flash_Config *config)
 
 int32_t Flash_quirkSpansionUNHYSADisable(Flash_Config *config)
 {
+    Flash_DevConfig *devCfg = config->devConfig;
     int32_t status = SystemP_SUCCESS;
     uint8_t regData = 0x00;
     uint32_t write = 0;
 
     /* Hybrid Sector Disable */
+    /* Read UNHYSA bit from CFR3V */
     status = Flash_norOspiRegRead(config, 0x65, 0x00800004, &regData);
+    if(status != SystemP_SUCCESS)
+    {
+        /* Failed to read CFR3V */
+        return status;
+    }
 
     if(status == SystemP_SUCCESS)
     {
@@ -1396,7 +1403,18 @@ int32_t Flash_quirkSpansionUNHYSADisable(Flash_Config *config)
 
     if(write)
     {
+        /* Write new value to CFR3N and CFR3V */
         status = Flash_norOspiRegWrite(config, 0x71, 0x04, regData);
+        if (status == SystemP_SUCCESS)
+        {
+            /* Wait for write command to finish */
+            Flash_norOspiWaitReady(config, devCfg->flashBusyTimeout);
+        }
+        else
+        {
+            /* Failed to write to CFR3N and CFR3V */
+            return status;
+        }
     }
 
     return status;


### PR DESCRIPTION
## Summary

Fix `Flash_quirkSpansionUNHYSADisable()` so that it waits for the non-volatile register write operation to complete before returning.

## Problem

`Flash_norOspiRegWrite()` updates both CFR3N and CFR3V registers through a non-volatile write operation. However, the current implementation does not wait for the flash device to become ready after issuing the write command.

As a result, subsequent flash operations or resets may occur while the non-volatile write is still in progress, potentially leaving the device in an undefined state.

## Fix

After a successful `Flash_norOspiRegWrite()`, call:

```c
Flash_norOspiWaitReady(config, devCfg->flashBusyTimeout);
```

to ensure the flash device has completed the internal write operation before continuing.

Additionally:

* Added explicit error handling for CFR3V read failures
* Added explicit error handling for CFR3N/CFR3V write failures

## Impact

This change only affects the hybrid sector disable quirk path and ensures proper synchronization with the flash device internal non-volatile write timing requirements.

## Tested

Tested on AM6442 EVM using the OSPI driver.
